### PR TITLE
Fix : 프로젝트 데이터를 불러올 때 오너의 profile도 불러오도록 수정

### DIFF
--- a/src/states/server/project/constants.ts
+++ b/src/states/server/project/constants.ts
@@ -2,6 +2,7 @@ import { PROFILE_ALL_DATA_QUERY } from "../profile/constants";
 
 export const PROJECT_ALL_DATA_QUERY = `
   *,
+  ownerProfile:profiles!inner(*),
   types:projectTypes!inner(...constantProjectTypes(*)),
   skills:projectSkills!inner(...constantSkills(*)),
   positions:projectPositions!inner(...constantPositions(*)),

--- a/src/states/server/project/types.ts
+++ b/src/states/server/project/types.ts
@@ -5,7 +5,7 @@ import type {
   ConstantProjectTypeRow,
   ConstantSkillRow
 } from "../constant";
-import type { ProfileAllDataRow } from "../profile";
+import type { ProfileAllDataRow, ProfileRow } from "../profile";
 import type { Table } from "../server.types";
 
 export type ProjectDataRow = Table["projects"]["Row"];
@@ -20,7 +20,8 @@ export type FollowProjectInsert = Table["followProject"]["Insert"];
 export type ProjectMembersRow = Table["projectMembers"]["Row"];
 
 export type ProjectAllDataRow = ProjectDataRow & {
-  projectTypes: ConstantProjectTypeRow[];
+  ownerProfile: ProfileRow;
+  types: ConstantProjectTypeRow[];
   skills: ConstantSkillRow[];
   positions: ConstantPositionRow[];
   languages: ConstantLanguageRow[];


### PR DESCRIPTION
# Describe your changes
- 프로젝트 데이터를 불러올때 onwer의 profile도 포함시켜서 fetch하도록 수정
## How to Test

## Next Step Todo (optional)

## Checklist

- [x] 🤔 이 프로젝트의 스타일 가이드를 따르나요?
- [x] 🤔 머지하기 전에 스스로 코드에 문제가 없음을 확인했나요?
- [x] 🤔 필요한 주석을 필요한 곳에 넣어주었나요?
- [x] ⛔️ (필수) base 브랜치를 pull 받았나요?!

## Questions

- 💬 질문 사항이에요!
- 🤷‍♂️ 확인 받고 싶은 부분이에요!
- 🔥 이건 꼭 확인해주세요!
