### PR TITLE
Fix : 프로젝트 데이터 fetch시 owner의 profile도 불러오도록 수정

### DIFF
--- a/src/pages/member/index.page.tsx
+++ b/src/pages/member/index.page.tsx
@@ -1,22 +1,7 @@
-import type { GetServerSideProps } from "next";
-import { serverSideTranslations } from "next-i18next/serverSideTranslations";
-import { useSelectOwnerProjectsQuery } from "~/states/server/project";
 import { Text } from "~/styles/mixins";
 
-const MY_ID = "d8b59089-521c-4c53-9483-8a0e70e3d42f";
-
 const Member = () => {
-  const { data } = useSelectOwnerProjectsQuery(MY_ID);
-  console.log(data);
   return <Text>member</Text>;
 };
 
 export default Member;
-
-export const getServerSideProps: GetServerSideProps = async (ctx) => {
-  return {
-    props: {
-      ...(await serverSideTranslations(ctx.locale, ["common"]))
-    }
-  };
-};

--- a/src/states/server/project/constants.ts
+++ b/src/states/server/project/constants.ts
@@ -3,6 +3,7 @@ import { PROFILE_ALL_DATA_QUERY } from "../profile/constants";
 export const PROJECT_ALL_DATA_QUERY = `
   *,
   projectType:constantProjectTypes(*),
+  ownerProfile:profiles!inner(*),
   skills:projectSkills!inner(...constantSkills(*)),
   positions:projectPositions!inner(...constantPositions(*)),
   languages:projectLanguages!inner(...constantLanguages(*)),

--- a/src/states/server/project/types.ts
+++ b/src/states/server/project/types.ts
@@ -5,7 +5,7 @@ import type {
   ConstantProjectTypeRow,
   ConstantSkillRow
 } from "../constant";
-import type { ProfileAllDataRow } from "../profile";
+import type { ProfileAllDataRow, ProfileRow } from "../profile";
 import type { Table } from "../server.types";
 
 export type ProjectDataRow = Table["projects"]["Row"];
@@ -21,6 +21,7 @@ export type ProjectMembersRow = Table["projectMembers"]["Row"];
 
 export type ProjectAllDataRow = Omit<ProjectDataRow, "projectType"> & {
   projectType: ConstantProjectTypeRow;
+  ownerProfile: ProfileRow;
   skills: ConstantSkillRow[];
   positions: ConstantPositionRow[];
   languages: ConstantLanguageRow[];


### PR DESCRIPTION
# Describe your changes
- 프로젝트 데이터 fetch할 때 owner의 간단한 프로필도 같이 불러오기
## How to Test

## Next Step Todo (optional)

## Checklist

- [x] 🤔 이 프로젝트의 스타일 가이드를 따르나요?
- [x] 🤔 머지하기 전에 스스로 코드에 문제가 없음을 확인했나요?
- [x] 🤔 필요한 주석을 필요한 곳에 넣어주었나요?
- [ ] ⛔️ (필수) base 브랜치를 pull 받았나요?!

## Questions

- 💬 질문 사항이에요!
- 🤷‍♂️ 확인 받고 싶은 부분이에요!
- 🔥 이건 꼭 확인해주세요!
